### PR TITLE
Add API Documentation link to account template swagger

### DIFF
--- a/src/views/account.tmpl
+++ b/src/views/account.tmpl
@@ -8,6 +8,7 @@
     <h2 class="title is-2">({{ len .Servers }}) Your bots</h2>
 
     <a class="button is-primary" href="/form/verify?mode=md">Add or Update Bot</a>
+    <a class="button is-primary" href="/swagger/index.html" target="_blank">📚 API Documentation</a>
 
     {{ if .HasMasterKey }}
       <div class="button">


### PR DESCRIPTION
- Add '📚 API Documentation' button to account.tmpl
- Button redirects to /swagger/index.html in new tab