### PR TITLE
Introduces support for automatic link, images, video and pdf previews

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,10 +13,10 @@ RUN go build -o service main.go
 # Run stage
 FROM golang:latest as src
 
-# 1) install ffmpeg here
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends ffmpeg
-RUN rm -rf /var/lib/apt/lists/*
+# Install ffmpeg (video thumbnails) and poppler-utils (PDF thumbnails)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg poppler-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/quepasa/
 

--- a/src/api/go.mod
+++ b/src/api/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nocodeleaks/quepasa/media v0.0.0-00010101000000-000000000000 // indirect
 	github.com/nocodeleaks/quepasa/signalr v0.0.0-00010101000000-000000000000 // indirect
 	github.com/petermattis/goid v0.0.0-20260113132338-7c7de50cc741 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nocodeleaks/quepasa/media v0.0.0-00010101000000-000000000000 // indirect
 	github.com/nocodeleaks/quepasa/rabbitmq v0.0.0-00010101000000-000000000000 // indirect
 	github.com/nocodeleaks/quepasa/signalr v0.0.0-00010101000000-000000000000 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -147,6 +147,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/src/go.work.sum
+++ b/src/go.work.sum
@@ -94,9 +94,9 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
-golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/net v0.45.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
 golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=

--- a/src/go.work.sum
+++ b/src/go.work.sum
@@ -68,6 +68,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/phpdave11/gofpdi v1.0.7 h1:k2oy4yhkQopCK+qW8KjCla0iU2RpDow+QUDmH9DDt44=
 github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=

--- a/src/library/go.mod
+++ b/src/library/go.mod
@@ -3,6 +3,7 @@ module github.com/nocodeleaks/quepasa/library
 require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/net v0.41.0
 )
 
 require (

--- a/src/library/opengraph.go
+++ b/src/library/opengraph.go
@@ -1,0 +1,257 @@
+package library
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/html"
+)
+
+// OpenGraphData holds Open Graph metadata from a URL
+type OpenGraphData struct {
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	ImageURL    string `json:"image_url"`
+}
+
+// Cache for Open Graph data
+type ogCacheEntry struct {
+	data      *OpenGraphData
+	timestamp time.Time
+}
+
+var (
+	ogCache    sync.Map
+	ogCacheTTL = 5 * time.Minute
+	ogTimeout  = 5 * time.Second
+	urlRegex   = regexp.MustCompile(`https?://[^\s<>"]+`)
+	httpClient *http.Client
+	clientOnce sync.Once
+)
+
+func getHTTPClient() *http.Client {
+	clientOnce.Do(func() {
+		httpClient = &http.Client{
+			Timeout: ogTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return fmt.Errorf("too many redirects")
+				}
+				return nil
+			},
+		}
+	})
+	return httpClient
+}
+
+// ExtractURLFromText extracts the first URL from a text string
+func ExtractURLFromText(text string) string {
+	match := urlRegex.FindString(text)
+	return match
+}
+
+// ExtractAllURLsFromText extracts all URLs from a text string
+func ExtractAllURLsFromText(text string) []string {
+	return urlRegex.FindAllString(text, -1)
+}
+
+// FetchOpenGraph fetches Open Graph metadata from a URL with caching
+func FetchOpenGraph(url string) (*OpenGraphData, error) {
+	// Check cache first
+	if cached, ok := ogCache.Load(url); ok {
+		entry := cached.(*ogCacheEntry)
+		if time.Since(entry.timestamp) < ogCacheTTL {
+			log.Debugf("opengraph cache hit for: %s", url)
+			return entry.data, nil
+		}
+		// Cache expired, remove it
+		ogCache.Delete(url)
+	}
+
+	log.Debugf("fetching opengraph for: %s", url)
+
+	// Fetch the URL
+	client := getHTTPClient()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set a browser-like User-Agent to avoid being blocked
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Limit reading to 1MB to prevent memory issues
+	limitedReader := io.LimitReader(resp.Body, 1024*1024)
+
+	// Parse HTML
+	data, err := parseOpenGraph(limitedReader, url)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store in cache
+	ogCache.Store(url, &ogCacheEntry{
+		data:      data,
+		timestamp: time.Now(),
+	})
+
+	return data, nil
+}
+
+// parseOpenGraph parses HTML and extracts Open Graph meta tags
+func parseOpenGraph(r io.Reader, originalURL string) (*OpenGraphData, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HTML: %w", err)
+	}
+
+	data := &OpenGraphData{
+		URL: originalURL,
+	}
+
+	var titleFromTag string
+
+	var parseNode func(*html.Node)
+	parseNode = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "meta":
+				var property, content string
+				var name string
+				for _, attr := range n.Attr {
+					switch attr.Key {
+					case "property":
+						property = attr.Val
+					case "name":
+						name = attr.Val
+					case "content":
+						content = attr.Val
+					}
+				}
+
+				// Check Open Graph properties
+				switch property {
+				case "og:title":
+					if data.Title == "" {
+						data.Title = content
+					}
+				case "og:description":
+					if data.Description == "" {
+						data.Description = content
+					}
+				case "og:image":
+					if data.ImageURL == "" {
+						data.ImageURL = content
+					}
+				case "og:url":
+					if content != "" {
+						data.URL = content
+					}
+				}
+
+				// Fallback to standard meta tags
+				switch name {
+				case "description":
+					if data.Description == "" {
+						data.Description = content
+					}
+				case "twitter:title":
+					if data.Title == "" {
+						data.Title = content
+					}
+				case "twitter:description":
+					if data.Description == "" {
+						data.Description = content
+					}
+				case "twitter:image":
+					if data.ImageURL == "" {
+						data.ImageURL = content
+					}
+				}
+
+			case "title":
+				// Extract <title> tag content as fallback
+				if n.FirstChild != nil && n.FirstChild.Type == html.TextNode {
+					titleFromTag = strings.TrimSpace(n.FirstChild.Data)
+				}
+			}
+		}
+
+		// Recursively parse child nodes
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			parseNode(c)
+		}
+	}
+
+	parseNode(doc)
+
+	// Use <title> tag as fallback if no og:title found
+	if data.Title == "" && titleFromTag != "" {
+		data.Title = titleFromTag
+	}
+
+	return data, nil
+}
+
+// DownloadImage downloads an image from a URL and returns the bytes
+func DownloadImage(url string) ([]byte, error) {
+	if url == "" {
+		return nil, fmt.Errorf("empty image URL")
+	}
+
+	log.Debugf("downloading image from: %s", url)
+
+	client := getHTTPClient()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected image status code: %d", resp.StatusCode)
+	}
+
+	// Limit image size to 5MB
+	limitedReader := io.LimitReader(resp.Body, 5*1024*1024)
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image: %w", err)
+	}
+
+	return data, nil
+}
+
+// ClearOpenGraphCache clears the Open Graph cache
+func ClearOpenGraphCache() {
+	ogCache.Range(func(key, value any) bool {
+		ogCache.Delete(key)
+		return true
+	})
+}

--- a/src/library/utils.go
+++ b/src/library/utils.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"mime"
 	"net/http"
@@ -146,4 +147,9 @@ func ToJson(in interface{}) string {
 		return string(bytes)
 	}
 	return ""
+}
+
+// DecodeBase64 decodes a base64 encoded string to bytes
+func DecodeBase64(data string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(data)
 }

--- a/src/media/go.mod
+++ b/src/media/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/cettoana/go-waveform v0.0.0-20210107122202-35aaec2de427
 	github.com/gopxl/beep/v2 v2.1.1 // A versão que você quer usar
 	github.com/mattetti/audio v0.0.0-20240411020228-c5379f9b5b61
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nocodeleaks/quepasa/whatsapp v0.0.0-00010101000000-000000000000
 	github.com/tcolgate/mp3 v0.0.0-20170426193717-e79c5a46d300
 )

--- a/src/media/thumbnail.go
+++ b/src/media/thumbnail.go
@@ -1,0 +1,343 @@
+package media
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	// Register image decoders
+	_ "image/gif"
+	_ "image/png"
+
+	"github.com/nfnt/resize"
+	log "github.com/sirupsen/logrus"
+)
+
+// ThumbnailConfig holds configuration for thumbnail generation
+type ThumbnailConfig struct {
+	MaxWidth  uint
+	MaxHeight uint
+	Quality   int // JPEG quality 1-100
+}
+
+// DefaultThumbnailConfig returns default thumbnail settings
+// WhatsApp typically uses 72x72 to 320x320 thumbnails
+func DefaultThumbnailConfig() ThumbnailConfig {
+	return ThumbnailConfig{
+		MaxWidth:  320,
+		MaxHeight: 320,
+		Quality:   75,
+	}
+}
+
+// Static flags for FFmpeg thumbnail availability
+var ffmpegThumbnailAvailable bool
+var ffmpegThumbnailOnce sync.Once
+
+// Static flags for Poppler (pdftoppm) availability
+var popplerAvailable bool
+var popplerOnce sync.Once
+
+// IsFFmpegThumbnailAvailable checks if FFmpeg is available for thumbnail generation
+func IsFFmpegThumbnailAvailable() bool {
+	ffmpegThumbnailOnce.Do(func() {
+		_, err := exec.LookPath("ffmpeg")
+		ffmpegThumbnailAvailable = (err == nil)
+		if !ffmpegThumbnailAvailable {
+			log.Warn("FFmpeg not available for thumbnail generation")
+		}
+	})
+	return ffmpegThumbnailAvailable
+}
+
+// IsPopplerAvailable checks if Poppler (pdftoppm) is available for PDF thumbnail generation
+func IsPopplerAvailable() bool {
+	popplerOnce.Do(func() {
+		_, err := exec.LookPath("pdftoppm")
+		popplerAvailable = (err == nil)
+		if !popplerAvailable {
+			log.Warn("Poppler (pdftoppm) not available for PDF thumbnail generation")
+		} else {
+			log.Debug("Poppler (pdftoppm) available for PDF thumbnail generation")
+		}
+	})
+	return popplerAvailable
+}
+
+// GenerateImageThumbnail creates a JPEG thumbnail from image data
+func GenerateImageThumbnail(imageData []byte, config ThumbnailConfig) ([]byte, error) {
+	if len(imageData) == 0 {
+		return nil, fmt.Errorf("empty image data")
+	}
+
+	// Decode image
+	img, format, err := image.Decode(bytes.NewReader(imageData))
+	if err != nil {
+		log.Debugf("Failed to decode image natively (format: %s): %v, trying FFmpeg", format, err)
+		// Try FFmpeg as fallback
+		return generateThumbnailWithFFmpeg(imageData, "image", config)
+	}
+
+	log.Debugf("Decoded image format: %s, size: %dx%d", format, img.Bounds().Dx(), img.Bounds().Dy())
+
+	// Resize image maintaining aspect ratio
+	thumbnail := resize.Thumbnail(config.MaxWidth, config.MaxHeight, img, resize.Lanczos3)
+
+	// Encode as JPEG
+	var buf bytes.Buffer
+	err = jpeg.Encode(&buf, thumbnail, &jpeg.Options{Quality: config.Quality})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode thumbnail as JPEG: %w", err)
+	}
+
+	log.Debugf("Generated image thumbnail: %d bytes", buf.Len())
+	return buf.Bytes(), nil
+}
+
+// GenerateVideoThumbnail creates a JPEG thumbnail from video data
+// Extracts frame at 1 second or first frame
+func GenerateVideoThumbnail(videoData []byte, config ThumbnailConfig) ([]byte, error) {
+	if len(videoData) == 0 {
+		return nil, fmt.Errorf("empty video data")
+	}
+
+	if !IsFFmpegThumbnailAvailable() {
+		return nil, fmt.Errorf("FFmpeg not available for video thumbnail generation")
+	}
+
+	return generateThumbnailWithFFmpeg(videoData, "video", config)
+}
+
+// GeneratePDFThumbnail creates a JPEG thumbnail from PDF data using Poppler (pdftoppm)
+// Renders first page as image
+func GeneratePDFThumbnail(pdfData []byte, config ThumbnailConfig) ([]byte, error) {
+	if len(pdfData) == 0 {
+		return nil, fmt.Errorf("empty PDF data")
+	}
+
+	if !IsPopplerAvailable() {
+		return nil, fmt.Errorf("Poppler (pdftoppm) not available for PDF thumbnail generation")
+	}
+
+	return generatePDFThumbnailWithPoppler(pdfData, config)
+}
+
+// generatePDFThumbnailWithPoppler uses Poppler's pdftoppm to generate PDF thumbnails
+func generatePDFThumbnailWithPoppler(pdfData []byte, config ThumbnailConfig) ([]byte, error) {
+	// Create temporary input file
+	inputFile, err := os.CreateTemp("", "thumb-input-*.pdf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp input file: %w", err)
+	}
+	defer os.Remove(inputFile.Name())
+
+	if _, err := inputFile.Write(pdfData); err != nil {
+		inputFile.Close()
+		return nil, fmt.Errorf("failed to write PDF data: %w", err)
+	}
+	inputFile.Close()
+
+	// Create temporary output file prefix (pdftoppm adds -1.jpg suffix)
+	outputPrefix, err := os.CreateTemp("", "thumb-output-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp output prefix: %w", err)
+	}
+	outputPrefixName := outputPrefix.Name()
+	outputPrefix.Close()
+	os.Remove(outputPrefixName) // pdftoppm will create the file
+
+	// The actual output file will be outputPrefixName-1.jpg
+	outputFileName := outputPrefixName + "-1.jpg"
+	defer os.Remove(outputFileName)
+	defer os.Remove(outputPrefixName) // cleanup prefix if exists
+
+	// Run pdftoppm command
+	// -jpeg: output as JPEG
+	// -f 1 -l 1: first page only
+	// -scale-to: scale to max dimension
+	// -singlefile: don't add page number suffix (but we handle it anyway)
+	cmd := exec.Command("pdftoppm",
+		"-jpeg",
+		"-f", "1",
+		"-l", "1",
+		"-scale-to", fmt.Sprintf("%d", config.MaxWidth),
+		inputFile.Name(),
+		outputPrefixName,
+	)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	log.Tracef("Executing pdftoppm command: %s", cmd.String())
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("pdftoppm thumbnail generation failed: %w\nstderr: %s", err, stderr.String())
+	}
+
+	// Read output file
+	thumbData, err := os.ReadFile(outputFileName)
+	if err != nil {
+		// Try without the -1 suffix (singlefile mode)
+		thumbData, err = os.ReadFile(outputPrefixName + ".jpg")
+		if err != nil {
+			return nil, fmt.Errorf("failed to read PDF thumbnail output: %w", err)
+		}
+		defer os.Remove(outputPrefixName + ".jpg")
+	}
+
+	log.Debugf("Generated PDF thumbnail with Poppler: %d bytes", len(thumbData))
+	return thumbData, nil
+}
+
+// generateThumbnailWithFFmpeg uses FFmpeg to generate thumbnails for videos and images
+func generateThumbnailWithFFmpeg(data []byte, mediaType string, config ThumbnailConfig) ([]byte, error) {
+	if !IsFFmpegThumbnailAvailable() {
+		return nil, fmt.Errorf("FFmpeg not available")
+	}
+
+	// Create temporary input file
+	var inputExt string
+	switch mediaType {
+	case "video":
+		inputExt = ".mp4"
+	default:
+		inputExt = ".bin"
+	}
+
+	inputFile, err := os.CreateTemp("", "thumb-input-*"+inputExt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp input file: %w", err)
+	}
+	defer os.Remove(inputFile.Name())
+
+	if _, err := inputFile.Write(data); err != nil {
+		inputFile.Close()
+		return nil, fmt.Errorf("failed to write input data: %w", err)
+	}
+	inputFile.Close()
+
+	// Create temporary output file
+	outputFile, err := os.CreateTemp("", "thumb-output-*.jpg")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp output file: %w", err)
+	}
+	defer os.Remove(outputFile.Name())
+	outputFile.Close()
+
+	// Build FFmpeg command based on media type
+	var cmd *exec.Cmd
+	scaleFilter := fmt.Sprintf("scale='min(%d,iw)':min'(%d,ih)':force_original_aspect_ratio=decrease",
+		config.MaxWidth, config.MaxHeight)
+
+	switch mediaType {
+	case "video":
+		// Extract frame at 1 second (or first frame if video is shorter)
+		cmd = exec.Command("ffmpeg",
+			"-i", inputFile.Name(),
+			"-ss", "00:00:01",
+			"-vframes", "1",
+			"-vf", scaleFilter,
+			"-f", "image2",
+			"-vcodec", "mjpeg",
+			"-q:v", "5",
+			"-y",
+			outputFile.Name(),
+		)
+	default:
+		// Generic image conversion
+		cmd = exec.Command("ffmpeg",
+			"-i", inputFile.Name(),
+			"-vf", scaleFilter,
+			"-f", "image2",
+			"-vcodec", "mjpeg",
+			"-q:v", "5",
+			"-y",
+			outputFile.Name(),
+		)
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	log.Tracef("Executing FFmpeg thumbnail command: %s", cmd.String())
+	err = cmd.Run()
+	if err != nil {
+		// For video, try without -ss if it failed (very short video)
+		if mediaType == "video" {
+			log.Debugf("FFmpeg with -ss failed, trying without: %v", err)
+			cmd = exec.Command("ffmpeg",
+				"-i", inputFile.Name(),
+				"-vframes", "1",
+				"-vf", scaleFilter,
+				"-f", "image2",
+				"-vcodec", "mjpeg",
+				"-q:v", "5",
+				"-y",
+				outputFile.Name(),
+			)
+			stderr.Reset()
+			cmd.Stderr = &stderr
+			err = cmd.Run()
+		}
+		if err != nil {
+			return nil, fmt.Errorf("FFmpeg thumbnail generation failed: %w\nstderr: %s", err, stderr.String())
+		}
+	}
+
+	// Read output
+	thumbData, err := os.ReadFile(outputFile.Name())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read thumbnail output: %w", err)
+	}
+
+	log.Debugf("Generated %s thumbnail with FFmpeg: %d bytes", mediaType, len(thumbData))
+	return thumbData, nil
+}
+
+// GenerateThumbnailByMime generates a thumbnail based on MIME type
+func GenerateThumbnailByMime(data []byte, mimeType string) ([]byte, error) {
+	config := DefaultThumbnailConfig()
+	mimeType = strings.ToLower(mimeType)
+
+	if strings.HasPrefix(mimeType, "image/") {
+		return GenerateImageThumbnail(data, config)
+	}
+
+	if strings.HasPrefix(mimeType, "video/") {
+		return GenerateVideoThumbnail(data, config)
+	}
+
+	// PDF thumbnail generation using Poppler (pdftoppm)
+	if mimeType == "application/pdf" {
+		return GeneratePDFThumbnail(data, config)
+	}
+
+	return nil, fmt.Errorf("unsupported MIME type for thumbnail generation: %s", mimeType)
+}
+
+// CanGenerateThumbnail checks if thumbnail generation is supported for a MIME type
+func CanGenerateThumbnail(mimeType string) bool {
+	mimeType = strings.ToLower(mimeType)
+
+	// Images - always supported (native Go decoding)
+	if strings.HasPrefix(mimeType, "image/") {
+		return true
+	}
+
+	// Videos - require FFmpeg
+	if strings.HasPrefix(mimeType, "video/") {
+		return IsFFmpegThumbnailAvailable()
+	}
+
+	// PDFs - require Poppler (pdftoppm)
+	if mimeType == "application/pdf" {
+		return IsPopplerAvailable()
+	}
+
+	return false
+}

--- a/src/models/qp_defaults.go
+++ b/src/models/qp_defaults.go
@@ -9,7 +9,7 @@ import (
 
 // quepasa build version, if ends with .0 means stable versions.
 // version 3.YY.MMDD.HHMM
-const QpVersion = "3.26.0129.2040"
+const QpVersion = "3.26.0202.1640"
 
 const QpLogLevel = log.InfoLevel
 

--- a/src/models/qp_send_any_request.go
+++ b/src/models/qp_send_any_request.go
@@ -28,6 +28,19 @@ type QpSendAnyRequest struct {
 
 	// BASE64 embed content
 	Content string `json:"content,omitempty"`
+
+	// Link Preview Options
+	// Enable automatic link preview fetching from URL in text
+	Preview bool `json:"preview,omitempty"`
+
+	// Custom title for link preview (overrides fetched title)
+	PreviewTitle string `json:"preview_title,omitempty"`
+
+	// Custom description for link preview (overrides fetched description)
+	PreviewDesc string `json:"preview_desc,omitempty"`
+
+	// Custom thumbnail URL for link preview (overrides fetched image)
+	PreviewThumb string `json:"preview_thumb,omitempty"`
 }
 
 // From BASE64 content

--- a/src/models/qp_send_request.go
+++ b/src/models/qp_send_request.go
@@ -48,6 +48,9 @@ type QpSendRequest struct {
 	Poll     *whatsapp.WhatsappPoll     `json:"poll,omitempty"`     // Poll if exists
 	Location *whatsapp.WhatsappLocation `json:"location,omitempty"` // Location if exists
 	Contact  *whatsapp.WhatsappContact  `json:"contact,omitempty"`  // Contact if exists
+
+	// Link preview data (populated by preview=true option)
+	LinkPreview *whatsapp.WhatsappMessageUrl `json:"-"` // Internal use only, not from JSON
 }
 
 // get default log entry, never nil
@@ -111,6 +114,11 @@ func (source *QpSendRequest) ToWhatsappMessage() (msg *whatsapp.WhatsappMessage,
 	}
 
 	msg.Poll = source.Poll
+
+	// Set link preview if available
+	if source.LinkPreview != nil {
+		msg.Url = source.LinkPreview
+	}
 
 	// Check if this is a contact message
 	if source.Contact != nil {

--- a/src/whatsmeow/go.mod
+++ b/src/whatsmeow/go.mod
@@ -35,6 +35,7 @@ toolchain go1.24.2
 require (
 	github.com/nocodeleaks/quepasa/environment v0.0.0-00010101000000-000000000000
 	github.com/nocodeleaks/quepasa/library v0.0.0-00010101000000-000000000000
+	github.com/nocodeleaks/quepasa/media v0.0.0-00010101000000-000000000000
 	github.com/nocodeleaks/quepasa/metrics v0.0.0-00010101000000-000000000000
 	github.com/nocodeleaks/quepasa/whatsapp v0.0.0-00010101000000-000000000000
 )
@@ -43,18 +44,27 @@ require (
 	github.com/beeper/argo-go v1.1.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cettoana/go-waveform v0.0.0-20210107122202-35aaec2de427 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/elliotchance/orderedmap/v3 v3.1.0 // indirect
 	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/gopxl/beep/v2 v2.1.1 // indirect
+	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
+	github.com/jfreymuth/oggvorbis v1.0.5 // indirect
+	github.com/jfreymuth/vorbis v1.0.2 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/mattetti/audio v0.0.0-20240411020228-c5379f9b5b61 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nocodeleaks/quepasa/webserver v0.0.0-00010101000000-000000000000 // indirect
 	github.com/petermattis/goid v0.0.0-20260113132338-7c7de50cc741 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	github.com/tcolgate/mp3 v0.0.0-20170426193717-e79c5a46d300 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.30 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/src/whatsmeow/whatsmeow_extensions.go
+++ b/src/whatsmeow/whatsmeow_extensions.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	media "github.com/nocodeleaks/quepasa/media"
 	whatsapp "github.com/nocodeleaks/quepasa/whatsapp"
 	log "github.com/sirupsen/logrus"
 	whatsmeow "go.mau.fi/whatsmeow"
@@ -72,6 +73,7 @@ func ToWhatsmeowMessage(source whatsapp.IWhatsappMessage) (msg *waE2E.Message, e
  * NewWhatsmeowMessageAttachment creates a new waE2E.Message with the correct media type and metadata.
  *
  * It builds the internal message (Image, Audio, Video, Document) using the upload response and WhatsappMessage data.
+ * Automatically generates thumbnails for images, videos, and PDFs when possible.
  *
  * @param response UploadResponse containing media upload info
  * @param waMsg WhatsappMessage containing attachment and text
@@ -79,7 +81,7 @@ func ToWhatsmeowMessage(source whatsapp.IWhatsappMessage) (msg *waE2E.Message, e
  * @param inreplycontext Optional context info for replies
  * @return waE2E.Message pointer with the correct media type
  */
-func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg whatsapp.WhatsappMessage, media whatsmeow.MediaType, inreplycontext *waE2E.ContextInfo) (msg *waE2E.Message) {
+func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg whatsapp.WhatsappMessage, mediaType whatsmeow.MediaType, inreplycontext *waE2E.ContextInfo) (msg *waE2E.Message) {
 	attach := waMsg.Attachment
 
 	var seconds *uint32
@@ -92,7 +94,25 @@ func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg what
 		mimetype = proto.String(attach.Mimetype)
 	}
 
-	switch media {
+	// Generate thumbnail if content is available
+	var thumbnail []byte
+	if attach.GetContent() != nil && len(*attach.GetContent()) > 0 {
+		content := *attach.GetContent()
+		mimeType := attach.Mimetype
+
+		// Check if we can generate a thumbnail for this type
+		if media.CanGenerateThumbnail(mimeType) {
+			thumbData, err := media.GenerateThumbnailByMime(content, mimeType)
+			if err != nil {
+				log.Debugf("Failed to generate thumbnail for %s: %v", mimeType, err)
+			} else {
+				thumbnail = thumbData
+				log.Debugf("Generated thumbnail for %s: %d bytes", mimeType, len(thumbData))
+			}
+		}
+	}
+
+	switch mediaType {
 	case whatsmeow.MediaImage:
 		internal := &waE2E.ImageMessage{
 			URL:           proto.String(response.URL),
@@ -104,6 +124,10 @@ func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg what
 			Mimetype:      mimetype,
 			Caption:       proto.String(waMsg.Text),
 			ContextInfo:   inreplycontext,
+		}
+		// Add thumbnail for images
+		if len(thumbnail) > 0 {
+			internal.JPEGThumbnail = thumbnail
 		}
 		msg = &waE2E.Message{ImageMessage: internal}
 		return
@@ -143,6 +167,10 @@ func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg what
 			Caption:       proto.String(waMsg.Text),
 			ContextInfo:   inreplycontext,
 		}
+		// Add thumbnail for videos
+		if len(thumbnail) > 0 {
+			internal.JPEGThumbnail = thumbnail
+		}
 		msg = &waE2E.Message{VideoMessage: internal}
 		return
 	default:
@@ -158,6 +186,10 @@ func NewWhatsmeowMessageAttachment(response whatsmeow.UploadResponse, waMsg what
 			FileName:    proto.String(attach.FileName),
 			Caption:     proto.String(waMsg.Text),
 			ContextInfo: inreplycontext,
+		}
+		// Add thumbnail for documents (PDFs mainly)
+		if len(thumbnail) > 0 {
+			internal.JPEGThumbnail = thumbnail
 		}
 		msg = &waE2E.Message{DocumentMessage: internal}
 		return


### PR DESCRIPTION
This pull request introduces support for automatic link previews (Open Graph metadata) in the message sending API, allowing users to send messages with rich previews of URLs. The implementation includes new API fields for customizing the preview, a new library for fetching and caching Open Graph data, and updates to documentation and dependencies.

**Link Preview Feature:**

- Added support for automatic link previews in the send message API, including new fields: `preview` (enable/disable), `preview_title`, `preview_desc`, and `preview_thumb` for customizing the preview content. The backend now extracts URLs from text, fetches Open Graph metadata, and attaches the preview to the outgoing message. [[1]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR28) [[2]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR39-R42) [[3]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR64-R82) [[4]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcL108-R132) [[5]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR218-R284)

- Updated API documentation and example requests to describe and demonstrate the new link preview functionality and its customizations. [[1]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR28) [[2]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR39-R42) [[3]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcR64-R82) [[4]](diffhunk://#diff-a3e1ef27ee599ab930bc01c5aff74ad178f2a395c7740649a6a21e9f95d002bcL108-R132)

**Library and Utility Enhancements:**

- Introduced a new `opengraph.go` library that fetches, parses, and caches Open Graph metadata from URLs, including robust error handling, HTTP client reuse, and HTML parsing. Also added an image downloader with size limits for preview thumbnails.

- Added utility functions for extracting URLs from text and decoding base64 strings. [[1]](diffhunk://#diff-c84bbcd93de070714346b171a8c2da17f9683e8879226af6a2b61069ff3db9a2R1-R257) [[2]](diffhunk://#diff-20443ed43e95c990bcd2113ed8142e228f1828d0813cc557008a9176147b6277R151-R155)

**Dependency and Build Updates:**

- Added `poppler-utils` to the Docker build for PDF thumbnail support and updated dependencies to include `github.com/nfnt/resize` and `golang.org/x/net` for image processing and HTML parsing. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL16-R19) [[2]](diffhunk://#diff-cec252b4ac7d8de58ffbbda3c1fb24f99ce3cfdee719e49ffcc11bff38c07656R78) [[3]](diffhunk://#diff-a232eda23ecdca6ddb9bc48029de26139b74f53d0a4a818fce89eec7d1b6a372R92) [[4]](diffhunk://#diff-4ebee47a2a1474d89ff397fb142e1664113dc91e0162707d6318eadeb964e118R71-R72) [[5]](diffhunk://#diff-4ebee47a2a1474d89ff397fb142e1664113dc91e0162707d6318eadeb964e118L97-R101) [[6]](diffhunk://#diff-05fd07529e0a2db2421e8783e6437a3168815dd7245244a781b10fb59cf3c368R6) [[7]](diffhunk://#diff-4aa7ee3452f1e2d70ca7b55d3146b0e42c9893314b6cca794ce0a5279f956afaR35)