### PR TITLE
Rreadupdate reimplantation per server

### DIFF
--- a/src/api/api_handlers+InformationController.go
+++ b/src/api/api_handlers+InformationController.go
@@ -20,7 +20,7 @@ import (
 //	@Tags			Information
 //	@Accept			json
 //	@Produce		json
-//	@Param			request	body		InfoCreateRequest	true	"Server creation request"
+//	@Param			request	body		InfoCreateRequest		true	"Server creation request"
 //	@Success		200		{object}	api.InformationResponse	"Server updated"
 //	@Success		201		{object}	api.InformationResponse	"Server created"
 //	@Failure		400		{object}	models.QpResponse

--- a/src/api/api_handlers+ScannerAndPairCodeController.go
+++ b/src/api/api_handlers+ScannerAndPairCodeController.go
@@ -100,10 +100,10 @@ func ValidateUsername(r *http.Request) (username string, ex ApiException) {
 //	@Description	Generates a pairing code for WhatsApp authentication using phone number
 //	@Tags			Connection
 //	@Produce		json
-//	@Param			phone	query		string	true	"Phone number for pairing"
-//	@Param			historysyncdays	query		int	false	"Days of message history to sync"
-//	@Success		200		{object}	models.QpResponse
-//	@Failure		400		{object}	models.QpResponse
+//	@Param			phone			query		string	true	"Phone number for pairing"
+//	@Param			historysyncdays	query		int		false	"Days of message history to sync"
+//	@Success		200				{object}	models.QpResponse
+//	@Failure		400				{object}	models.QpResponse
 //	@Security		ApiKeyAuth
 //	@Router			/paircode [get]
 func PairCodeController(w http.ResponseWriter, r *http.Request) {

--- a/src/api/api_handlers.go
+++ b/src/api/api_handlers.go
@@ -224,11 +224,11 @@ func RegisterAPIControllers(r chi.Router) {
 // CommandController manages bot server commands
 //
 //	@Summary		Execute bot commands
-//	@Description	Execute control commands for the bot server (start, stop, restart)
+//	@Description	Execute control commands for the bot server (start, stop, restart) or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)
 //	@Tags			Bot
 //	@Accept			json
 //	@Produce		json
-//	@Param			action	query		string	true	"Command action"	Enums(start, stop, restart)
+//	@Param			action	query		string	true	"Command action"	Enums(start, stop, restart, groups, broadcasts, readreceipts, readupdate, calls, debug)
 //	@Success		200		{object}	models.QpResponse
 //	@Failure		400		{object}	models.QpResponse
 //	@Security		ApiKeyAuth
@@ -289,6 +289,12 @@ func CommandController(w http.ResponseWriter, r *http.Request) {
 			message := "calls toggled: " + server.Calls.String()
 			response.ParseSuccess(message)
 		}
+	case "readupdate":
+		err := models.ToggleReadUpdate(server)
+		if err == nil {
+			message := "readupdate toggled: " + server.ReadUpdate.String()
+			response.ParseSuccess(message)
+		}
 	case "debug":
 		_, err := server.ToggleDevel()
 		if err == nil {
@@ -296,7 +302,7 @@ func CommandController(w http.ResponseWriter, r *http.Request) {
 			response.ParseSuccess(message)
 		}
 	default:
-		err = fmt.Errorf("invalid action: {%s}, try {start,stop,restart,groups,broadcasts,readreceipts,calls,debug}", action)
+		err = fmt.Errorf("invalid action: {%s}, try {start,stop,restart,groups,broadcasts,readreceipts,readupdate,calls,debug}", action)
 	}
 
 	if err != nil {

--- a/src/environment/api_settings.go
+++ b/src/environment/api_settings.go
@@ -4,39 +4,39 @@ import "time"
 
 // API environment variable names
 const (
-	ENV_WEBSOCKETSSL = "WEBSOCKETSSL"    // use SSL for websocket qrcode
-	ENV_SIGNING_SECRET = "SIGNING_SECRET"  // token for hash signing cookies
-	ENV_MASTER_KEY   = "MASTERKEY"       // used for manage all instances at all
+	ENV_WEBSOCKETSSL    = "WEBSOCKETSSL"    // use SSL for websocket qrcode
+	ENV_SIGNING_SECRET  = "SIGNING_SECRET"  // token for hash signing cookies
+	ENV_MASTER_KEY      = "MASTERKEY"       // used for manage all instances at all
 	ENV_WEBHOOK_TIMEOUT = "WEBHOOK_TIMEOUT" // timeout in milliseconds for webhook requests
-	ENV_API_PREFIX   = "API_PREFIX"      // API routes prefix
-	ENV_API_TIMEOUT  = "API_TIMEOUT"     // API request timeout in milliseconds
-	ENV_USER         = "USER"            // default user for database seeding
-	ENV_PASSWORD     = "PASSWORD"        // default password for database seeding
+	ENV_API_PREFIX      = "API_PREFIX"      // API routes prefix
+	ENV_API_TIMEOUT     = "API_TIMEOUT"     // API request timeout in milliseconds
+	ENV_USER            = "USER"            // default user for database seeding
+	ENV_PASSWORD        = "PASSWORD"        // default password for database seeding
 )
 
 // APISettings holds all API configuration loaded from environment
 type APISettings struct {
-	UseSSLWebSocket  bool   `json:"use_ssl_websocket"`
-	SigningSecret    string `json:"signing_secret"`
-	MasterKey        string `json:"master_key"`
-	WebhookTimeout   uint32 `json:"webhook_timeout"` // webhook timeout in milliseconds
-	Prefix           string `json:"prefix"`
-	Timeout          uint32 `json:"timeout"` // API request timeout in milliseconds
-	User             string `json:"user"`     // default user for database seeding
-	Password         string `json:"password"` // default password for database seeding
+	UseSSLWebSocket bool   `json:"use_ssl_websocket"`
+	SigningSecret   string `json:"signing_secret"`
+	MasterKey       string `json:"master_key"`
+	WebhookTimeout  uint32 `json:"webhook_timeout"` // webhook timeout in milliseconds
+	Prefix          string `json:"prefix"`
+	Timeout         uint32 `json:"timeout"`  // API request timeout in milliseconds
+	User            string `json:"user"`     // default user for database seeding
+	Password        string `json:"password"` // default password for database seeding
 }
 
 // NewAPISettings creates a new API settings by loading all values from environment
 func NewAPISettings() APISettings {
 	return APISettings{
-		UseSSLWebSocket:   getEnvOrDefaultBool(ENV_WEBSOCKETSSL, false),
-		SigningSecret:     getEnvOrDefaultString(ENV_SIGNING_SECRET, ""),
-		MasterKey:         getEnvOrDefaultString(ENV_MASTER_KEY, ""),
-		WebhookTimeout:    getEnvOrDefaultUint32(ENV_WEBHOOK_TIMEOUT, 10000),
-		Prefix:            getEnvOrDefaultString(ENV_API_PREFIX, ""),
-		Timeout:           getEnvOrDefaultUint32(ENV_API_TIMEOUT, 30000),
-		User:              getEnvOrDefaultString(ENV_USER, ""),
-		Password:          getEnvOrDefaultString(ENV_PASSWORD, ""),
+		UseSSLWebSocket: getEnvOrDefaultBool(ENV_WEBSOCKETSSL, false),
+		SigningSecret:   getEnvOrDefaultString(ENV_SIGNING_SECRET, ""),
+		MasterKey:       getEnvOrDefaultString(ENV_MASTER_KEY, ""),
+		WebhookTimeout:  getEnvOrDefaultUint32(ENV_WEBHOOK_TIMEOUT, 10000),
+		Prefix:          getEnvOrDefaultString(ENV_API_PREFIX, ""),
+		Timeout:         getEnvOrDefaultUint32(ENV_API_TIMEOUT, 30000),
+		User:            getEnvOrDefaultString(ENV_USER, ""),
+		Password:        getEnvOrDefaultString(ENV_PASSWORD, ""),
 	}
 }
 

--- a/src/environment/environment_settings_preview.go
+++ b/src/environment/environment_settings_preview.go
@@ -9,18 +9,18 @@ import (
 // EnvironmentSettingsPreview provides a read-only preview of environment settings
 // Used for public endpoints without authentication
 type EnvironmentSettingsPreview struct {
-	Groups               string `json:"groups"`
-	Broadcasts           string `json:"broadcasts"`
-	ReadReceipts         string `json:"read_receipts"`
-	Calls                string `json:"calls"`
-	HistorySync          string `json:"history_sync"`
-	LogLevel             string `json:"log_level"`
-	DBLogLevel           string `json:"db_log_level,omitempty"`
-	RetryMessageStore    string `json:"retry_message_store,omitempty"`
-	Presence             string `json:"presence,omitempty"`
-	ReadUpdate           string `json:"read_update,omitempty"`
-	WakeUpHour           string `json:"wakeup_hour,omitempty"`
-	WakeUpDuration       string `json:"wakeup_duration,omitempty"`
+	Groups            string `json:"groups"`
+	Broadcasts        string `json:"broadcasts"`
+	ReadReceipts      string `json:"read_receipts"`
+	Calls             string `json:"calls"`
+	HistorySync       string `json:"history_sync"`
+	LogLevel          string `json:"log_level"`
+	DBLogLevel        string `json:"db_log_level,omitempty"`
+	RetryMessageStore string `json:"retry_message_store,omitempty"`
+	Presence          string `json:"presence,omitempty"`
+	ReadUpdate        string `json:"read_update,omitempty"`
+	WakeUpHour        string `json:"wakeup_hour,omitempty"`
+	WakeUpDuration    string `json:"wakeup_duration,omitempty"`
 }
 
 // GetPreview returns a read-only preview of current environment settings

--- a/src/environment/whatsmeow_settings.go
+++ b/src/environment/whatsmeow_settings.go
@@ -2,9 +2,9 @@ package environment
 
 // WhatsApp environment variable names
 const (
-	ENV_DISPATCH_UNHANDLED                = "DISPATCHUNHANDLED"                // enable or disable dispatch unhandled messages
-	ENV_WHATSMEOWLOGLEVEL                 = "WHATSMEOW_LOGLEVEL"               // Whatsmeow log level
-	ENV_WHATSMEOWDBLOGLEVEL               = "WHATSMEOW_DBLOGLEVEL"             // Whatsmeow database log level
+	ENV_DISPATCH_UNHANDLED                = "DISPATCHUNHANDLED"                 // enable or disable dispatch unhandled messages
+	ENV_WHATSMEOWLOGLEVEL                 = "WHATSMEOW_LOGLEVEL"                // Whatsmeow log level
+	ENV_WHATSMEOWDBLOGLEVEL               = "WHATSMEOW_DBLOGLEVEL"              // Whatsmeow database log level
 	ENV_WHATSMEOW_USE_RETRY_MESSAGE_STORE = "WHATSMEOW_USE_RETRY_MESSAGE_STORE" // persist outgoing messages for retry receipts
 )
 

--- a/src/form/form_extensions.go
+++ b/src/form/form_extensions.go
@@ -92,6 +92,11 @@ func FormToggleController(w http.ResponseWriter, r *http.Request) {
 					err = models.ToggleCalls(server)
 					break
 				}
+			case "server-readupdate":
+				{
+					err = models.ToggleReadUpdate(server)
+					break
+				}
 
 			default:
 				{

--- a/src/migrations/202512231500_add_readupdate.up.sql
+++ b/src/migrations/202512231500_add_readupdate.up.sql
@@ -1,20 +1,4 @@
-CREATE TABLE IF NOT EXISTS `servers_202512231500` (
-  `token` CHAR (100) PRIMARY KEY UNIQUE NOT NULL,
-  `wid` VARCHAR (255) UNIQUE NOT NULL,
-  `verified` BOOLEAN NOT NULL DEFAULT FALSE,
-  `devel` BOOLEAN NOT NULL DEFAULT FALSE,
-  `groups` INT(1) NOT NULL DEFAULT 0,
-  `broadcasts` INT(1) NOT NULL DEFAULT 0,
-  `readreceipts` INT(1) NOT NULL DEFAULT 0,
-  `calls` INT(1) NOT NULL DEFAULT 0,
-  `readupdate` INT(1) NOT NULL DEFAULT 0,
-  `user` CHAR (255) DEFAULT NULL REFERENCES `users`(`username`),
-  `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-INSERT INTO `servers_202512231500`(`token`, `wid`, `verified`, `devel`, `groups`, `broadcasts`, `readreceipts`, `calls`, `user`)
-SELECT `token`, `wid`, `verified`, `devel`, `groups`, `broadcasts`, `readreceipts`, `calls`, `user`
-FROM `servers`;
-
-DROP TABLE `servers`;
-ALTER TABLE `servers_202512231500` RENAME TO `servers`;
+-- Add readupdate column to servers table
+-- Using ALTER TABLE ADD COLUMN to avoid foreign key constraint issues
+-- (dispatching table references servers.token)
+ALTER TABLE `servers` ADD COLUMN `readupdate` INT(1) NOT NULL DEFAULT 0;

--- a/src/models/qp_data_server_sql.go
+++ b/src/models/qp_data_server_sql.go
@@ -42,13 +42,13 @@ func (source QpDataServerSql) FindByToken(token string) (response *QpServer, err
 }
 
 func (source QpDataServerSql) Add(element *QpServer) error {
-	query := `INSERT INTO servers (token, wid, verified, devel, groups, broadcasts, readreceipts, calls, user) VALUES (:token, :wid, :verified, :devel, :groups, :broadcasts, :readreceipts, :calls, :user)`
+	query := `INSERT INTO servers (token, wid, verified, devel, groups, broadcasts, readreceipts, calls, readupdate, user) VALUES (:token, :wid, :verified, :devel, :groups, :broadcasts, :readreceipts, :calls, :readupdate, :user)`
 	_, err := source.db.NamedExec(query, element)
 	return err
 }
 
 func (source QpDataServerSql) Update(element *QpServer) error {
-	query := `UPDATE servers SET wid = :wid, verified = :verified, devel = :devel, groups = :groups, broadcasts = :broadcasts, readreceipts = :readreceipts, calls = :calls, user = :user WHERE token = :token`
+	query := `UPDATE servers SET wid = :wid, verified = :verified, devel = :devel, groups = :groups, broadcasts = :broadcasts, readreceipts = :readreceipts, calls = :calls, readupdate = :readupdate, user = :user WHERE token = :token`
 	_, err := source.db.NamedExec(query, element)
 	return err
 }

--- a/src/models/qp_defaults.go
+++ b/src/models/qp_defaults.go
@@ -9,7 +9,7 @@ import (
 
 // quepasa build version format has 4 sections only: 3.YY.MMDD.HHMM
 // stable versions are identified when HHMM last digit is 0
-const QpVersion = "3.26.0220.1300"
+const QpVersion = "3.26.0228.0225"
 
 const QpLogLevel = log.InfoLevel
 

--- a/src/models/qp_server.go
+++ b/src/models/qp_server.go
@@ -84,6 +84,11 @@ func (source QpServer) IsSetReadUpdate() bool {
 }
 
 // used for view
+func (source QpServer) GetReadUpdate() bool {
+	return source.ReadUpdate.Boolean()
+}
+
+// used for view
 func (source QpServer) GetCalls() bool {
 	return source.Calls.Boolean()
 }

--- a/src/models/qp_whatsapp_extensions.go
+++ b/src/models/qp_whatsapp_extensions.go
@@ -300,4 +300,20 @@ func ToggleCalls(source whatsapp.IWhatsappOptions) error {
 	return source.Save(reason)
 }
 
+func ToggleReadUpdate(source whatsapp.IWhatsappOptions) error {
+	options := source.GetOptions()
+
+	switch options.ReadUpdate {
+	case whatsapp.UnSetBooleanType:
+		options.ReadUpdate = whatsapp.TrueBooleanType
+	case whatsapp.TrueBooleanType:
+		options.ReadUpdate = whatsapp.FalseBooleanType
+	default:
+		options.ReadUpdate = whatsapp.UnSetBooleanType
+	}
+
+	reason := fmt.Sprintf("toggle read update: %s", options.ReadUpdate)
+	return source.Save(reason)
+}
+
 //#endregion

--- a/src/swagger/docs.go
+++ b/src/swagger/docs.go
@@ -1776,7 +1776,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Retrieves pending messages from WhatsApp with optional timestamp filtering and exceptions error filtering",
+                "description": "Retrieves pending messages from WhatsApp with optional cache filters",
                 "consumes": [
                     "application/json"
                 ],
@@ -1798,6 +1798,54 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by exceptions error status: 'true' for messages with exceptions errors, 'false' for messages without exceptions errors, omit for all messages",
                         "name": "exceptions",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by message type (supports comma-separated list)",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by category: sent, received, sync, unhandled, events",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search text in id, chat, text, trackid, participant and exceptions",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by fromme boolean: true or false",
+                        "name": "fromme",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by fromhistory boolean: true or false",
+                        "name": "fromhistory",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by chat id (contains)",
+                        "name": "chatid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by message id (contains)",
+                        "name": "messageid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by track id (contains)",
+                        "name": "trackid",
                         "in": "query"
                     }
                 ],
@@ -2673,6 +2721,10 @@ const docTemplate = `{
                 "master_key": {
                     "type": "string"
                 },
+                "password": {
+                    "description": "default password for database seeding",
+                    "type": "string"
+                },
                 "prefix": {
                     "type": "string"
                 },
@@ -2685,6 +2737,10 @@ const docTemplate = `{
                 },
                 "use_ssl_websocket": {
                     "type": "boolean"
+                },
+                "user": {
+                    "description": "default user for database seeding",
+                    "type": "string"
                 },
                 "webhook_timeout": {
                     "description": "webhook timeout in milliseconds",
@@ -2805,6 +2861,9 @@ const docTemplate = `{
                 "read_update": {
                     "type": "string"
                 },
+                "retry_message_store": {
+                    "type": "string"
+                },
                 "wakeup_duration": {
                     "type": "string"
                 },
@@ -2846,6 +2905,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "convert_wave_to_ogg": {
+                    "type": "boolean"
+                },
+                "force_audio_as_ptt": {
                     "type": "boolean"
                 },
                 "log_level": {
@@ -3025,6 +3087,9 @@ const docTemplate = `{
                 },
                 "whatsmeow_log_level": {
                     "type": "string"
+                },
+                "whatsmeow_use_retry_message_store": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/swagger/docs.go
+++ b/src/swagger/docs.go
@@ -280,7 +280,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Execute control commands for the bot server (start, stop, restart)",
+                "description": "Execute control commands for the bot server (start, stop, restart) or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)",
                 "consumes": [
                     "application/json"
                 ],
@@ -296,7 +296,13 @@ const docTemplate = `{
                         "enum": [
                             "start",
                             "stop",
-                            "restart"
+                            "restart",
+                            "groups",
+                            "broadcasts",
+                            "readreceipts",
+                            "readupdate",
+                            "calls",
+                            "debug"
                         ],
                         "type": "string",
                         "description": "Command action",

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -277,7 +277,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Execute control commands for the bot server (start, stop, restart)",
+                "description": "Execute control commands for the bot server (start, stop, restart) or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)",
                 "consumes": [
                     "application/json"
                 ],
@@ -293,7 +293,13 @@
                         "enum": [
                             "start",
                             "stop",
-                            "restart"
+                            "restart",
+                            "groups",
+                            "broadcasts",
+                            "readreceipts",
+                            "readupdate",
+                            "calls",
+                            "debug"
                         ],
                         "type": "string",
                         "description": "Command action",

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -1773,7 +1773,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Retrieves pending messages from WhatsApp with optional timestamp filtering and exceptions error filtering",
+                "description": "Retrieves pending messages from WhatsApp with optional cache filters",
                 "consumes": [
                     "application/json"
                 ],
@@ -1795,6 +1795,54 @@
                         "type": "string",
                         "description": "Filter by exceptions error status: 'true' for messages with exceptions errors, 'false' for messages without exceptions errors, omit for all messages",
                         "name": "exceptions",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by message type (supports comma-separated list)",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by category: sent, received, sync, unhandled, events",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search text in id, chat, text, trackid, participant and exceptions",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by fromme boolean: true or false",
+                        "name": "fromme",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by fromhistory boolean: true or false",
+                        "name": "fromhistory",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by chat id (contains)",
+                        "name": "chatid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by message id (contains)",
+                        "name": "messageid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by track id (contains)",
+                        "name": "trackid",
                         "in": "query"
                     }
                 ],
@@ -2670,6 +2718,10 @@
                 "master_key": {
                     "type": "string"
                 },
+                "password": {
+                    "description": "default password for database seeding",
+                    "type": "string"
+                },
                 "prefix": {
                     "type": "string"
                 },
@@ -2682,6 +2734,10 @@
                 },
                 "use_ssl_websocket": {
                     "type": "boolean"
+                },
+                "user": {
+                    "description": "default user for database seeding",
+                    "type": "string"
                 },
                 "webhook_timeout": {
                     "description": "webhook timeout in milliseconds",
@@ -2802,6 +2858,9 @@
                 "read_update": {
                     "type": "string"
                 },
+                "retry_message_store": {
+                    "type": "string"
+                },
                 "wakeup_duration": {
                     "type": "string"
                 },
@@ -2843,6 +2902,9 @@
                     "type": "boolean"
                 },
                 "convert_wave_to_ogg": {
+                    "type": "boolean"
+                },
+                "force_audio_as_ptt": {
                     "type": "boolean"
                 },
                 "log_level": {
@@ -3022,6 +3084,9 @@
                 },
                 "whatsmeow_log_level": {
                     "type": "string"
+                },
+                "whatsmeow_use_retry_message_store": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/swagger/swagger.yaml
+++ b/src/swagger/swagger.yaml
@@ -1426,13 +1426,19 @@ paths:
     get:
       consumes:
       - application/json
-      description: Execute control commands for the bot server (start, stop, restart)
+      description: Execute control commands for the bot server (start, stop, restart) or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)
       parameters:
       - description: Command action
         enum:
         - start
         - stop
         - restart
+        - groups
+        - broadcasts
+        - readreceipts
+        - readupdate
+        - calls
+        - debug
         in: query
         name: action
         required: true

--- a/src/swagger/swagger.yaml
+++ b/src/swagger/swagger.yaml
@@ -170,6 +170,9 @@ definitions:
     properties:
       master_key:
         type: string
+      password:
+        description: default password for database seeding
+        type: string
       prefix:
         type: string
       signing_secret:
@@ -179,6 +182,9 @@ definitions:
         type: integer
       use_ssl_websocket:
         type: boolean
+      user:
+        description: default user for database seeding
+        type: string
       webhook_timeout:
         description: webhook timeout in milliseconds
         type: integer
@@ -257,6 +263,8 @@ definitions:
         type: string
       read_update:
         type: string
+      retry_message_store:
+        type: string
       wakeup_duration:
         type: string
       wakeup_hour:
@@ -284,6 +292,8 @@ definitions:
       convert_png_to_jpg:
         type: boolean
       convert_wave_to_ogg:
+        type: boolean
+      force_audio_as_ptt:
         type: boolean
       log_level:
         type: string
@@ -402,6 +412,8 @@ definitions:
         type: string
       whatsmeow_log_level:
         type: string
+      whatsmeow_use_retry_message_store:
+        type: boolean
     type: object
   models.QpContactsResponse:
     properties:
@@ -1426,7 +1438,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: Execute control commands for the bot server (start, stop, restart) or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)
+      description: Execute control commands for the bot server (start, stop, restart)
+        or toggle settings (groups, broadcasts, readreceipts, readupdate, calls, debug)
       parameters:
       - description: Command action
         enum:
@@ -2371,8 +2384,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieves pending messages from WhatsApp with optional timestamp
-        filtering and exceptions error filtering
+      description: Retrieves pending messages from WhatsApp with optional cache filters
       parameters:
       - description: Timestamp filter for messages
         in: query
@@ -2383,6 +2395,38 @@ paths:
           for all messages'
         in: query
         name: exceptions
+        type: string
+      - description: Filter by message type (supports comma-separated list)
+        in: query
+        name: type
+        type: string
+      - description: 'Filter by category: sent, received, sync, unhandled, events'
+        in: query
+        name: category
+        type: string
+      - description: Search text in id, chat, text, trackid, participant and exceptions
+        in: query
+        name: search
+        type: string
+      - description: 'Filter by fromme boolean: true or false'
+        in: query
+        name: fromme
+        type: string
+      - description: 'Filter by fromhistory boolean: true or false'
+        in: query
+        name: fromhistory
+        type: string
+      - description: Filter by chat id (contains)
+        in: query
+        name: chatid
+        type: string
+      - description: Filter by message id (contains)
+        in: query
+        name: messageid
+        type: string
+      - description: Filter by track id (contains)
+        in: query
+        name: trackid
         type: string
       produces:
       - application/json

--- a/src/views/account.tmpl
+++ b/src/views/account.tmpl
@@ -22,6 +22,11 @@
       </div>
     {{ end }}
 
+    <a class="button is-info" href="/swagger/index.html" target="_blank">
+      <span class="icon"><i class="fas fa-book"></i></span>
+      <span>Swagger</span>
+    </a>
+
     {{ if .ErrorMessage }}
       <div class="notification is-warning">
         {{ .ErrorMessage }}
@@ -111,6 +116,14 @@
                       </button>
                     </form>
                   </p>
+                  <p class="control"> 
+                    <form class="" method="post" action="/form/toggle?key=server-readupdate" data-value="{{ .ReadUpdate }}">
+                      <input name="token" type="hidden" value="{{ .Token }}">
+                      <button class="button {{ if .IsSetReadUpdate }}{{ if .GetReadUpdate }}is-info is-hovered{{ else }}is-danger is-hovered{{ end }}{{ end }}" title="Handle Read Update">
+                        <span class="icon is-small is-inline"><i class="fa fa-eye"></i></span>
+                      </button>
+                    </form>
+                  </p>
                 {{ end }}
                 <p>&nbsp;&nbsp;</p>
                 <p class="control">
@@ -181,6 +194,7 @@
           {{ if .Options.Calls }}<p>Calls: {{ .Options.Calls.String  }}</p>{{ end }}
           {{ if .Options.HistorySync }}<p>HistorySync: {{ .Options.HistorySync  }} days</p>{{ end }}
           {{ if .Options.LogLevel }}<p>LogLevel: {{ .Options.LogLevel  }}</p>{{ end }}
+          {{ if .Options.ReadUpdate }}<p>ReadUpdate: {{ .Options.ReadUpdate }}</p>{{ end }}
         </div>
       </div>
     {{ end }}

--- a/src/whatsmeow/whatsmeow_handlers_message_extensions.go
+++ b/src/whatsmeow/whatsmeow_handlers_message_extensions.go
@@ -258,13 +258,13 @@ func HandleReactionMessage(log *log.Entry, out *whatsapp.WhatsappMessage, in *wa
 
 	out.Type = whatsapp.TextMessageType
 	out.Text = in.GetText()
-	
+
 	// marking as reaction
 	out.InReaction = true
-	
+
 	// setting the message ID being reacted to
 	out.InReply = in.Key.GetID()
-	
+
 	// If text is empty, it means the reaction was removed
 	if out.Text == "" {
 		out.Info = "reaction removed"


### PR DESCRIPTION
This pull request introduces support for a new `readupdate` setting in the bot server, allowing toggling and management of this feature via API and forms. It also expands the API documentation and Swagger definitions to reflect these changes and adds several new message filtering options for pending WhatsApp messages. The migration script updates the database schema to support the new setting.

**Feature: Add `readupdate` toggle and support**

* Added `readupdate` as a toggleable command action in the bot server API, including endpoint and documentation updates (`src/api/api_handlers.go`, `src/swagger/docs.go`, `src/swagger/swagger.json`). [[1]](diffhunk://#diff-6ae63fe88848d954903f2d9d91c969a4e284292b7d0ddb3a3dc2ef634f64929eL227-R231) [[2]](diffhunk://#diff-6ae63fe88848d954903f2d9d91c969a4e284292b7d0ddb3a3dc2ef634f64929eR292-R305) [[3]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778L283-R283) [[4]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778L299-R305) [[5]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fL280-R280) [[6]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fL296-R302)
* Implemented `ToggleReadUpdate` logic and view accessor methods in the models to handle the new setting (`src/models/qp_whatsapp_extensions.go`, `src/models/qp_server.go`). [[1]](diffhunk://#diff-c877f298dfa83ff1754fded0ee2a3a2dba25cee202e575a5c4282d5112cd8ae0R303-R318) [[2]](diffhunk://#diff-c22428e309f8b2356ee06e09f5d178d89ac055a323972ffcc9b0d859332b1a46R86-R90)
* Updated forms controller to support toggling `readupdate` (`src/form/form_extensions.go`).

**Database schema changes**

* Migration script altered to add a `readupdate` column to the `servers` table, using `ALTER TABLE` for safer migration (`src/migrations/202512231500_add_readupdate.up.sql`).
* Updated SQL queries for adding and updating servers to include the new `readupdate` field (`src/models/qp_data_server_sql.go`).

**API documentation and Swagger improvements**

* Expanded Swagger and OpenAPI docs to include the new `readupdate` command and additional message filtering options (type, category, search, fromme, fromhistory, chatid, messageid, trackid) for pending messages endpoints (`src/swagger/docs.go`, `src/swagger/swagger.json`). [[1]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778L1773-R1779) [[2]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R1802-R1849) [[3]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fL1770-R1776) [[4]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR1799-R1846)
* Added new fields for database seeding and WhatsApp options in Swagger definitions (`src/swagger/docs.go`, `src/swagger/swagger.json`, `src/swagger/swagger.yaml`). [[1]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R2724-R2727) [[2]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R2741-R2744) [[3]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R2864-R2866) [[4]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R2910-R2912) [[5]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R3090-R3092) [[6]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR2721-R2724) [[7]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR2738-R2741) [[8]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR2861-R2863) [[9]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR2907-R2909) [[10]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR3087-R3089) [[11]](diffhunk://#diff-63ea78f739530e7b938895275735c4444a674ff143393c1455cdf77373db44e7R173-R175)