### PR TITLE
✨ feat: add support for PTV messages and related tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ main.exe
 .dist/win-quepasa-service.exe
 **/.token
 .telegram.token
+src/.gocache

--- a/src/models/qp_defaults.go
+++ b/src/models/qp_defaults.go
@@ -9,7 +9,7 @@ import (
 
 // quepasa build version format has 4 sections only: 3.YY.MMDD.HHMM
 // stable versions are identified when HHMM last digit is 0
-const QpVersion = "3.26.0309.1531"
+const QpVersion = "3.26.0309.1600"
 
 const QpLogLevel = log.InfoLevel
 

--- a/src/whatsapp/whatsapp_message.go
+++ b/src/whatsapp/whatsapp_message.go
@@ -51,6 +51,9 @@ type WhatsappMessage struct {
 	// When true with empty Text, indicates a reaction removal
 	InReaction bool `json:"inreaction,omitempty"`
 
+	// Is this video message a video note (PTV Message)?
+	InVideoNote bool `json:"invideonote,omitempty"`
+
 	// Msg in reply of another ? Message ID
 	InReply string `json:"inreply,omitempty"`
 

--- a/src/whatsmeow/whatsmeow_extensions.go
+++ b/src/whatsmeow/whatsmeow_extensions.go
@@ -306,6 +306,10 @@ func GetDownloadableMessage(msg *waE2E.Message) whatsmeow.DownloadableMessage {
 		return msg.VideoMessage
 	}
 
+	if msg.PtvMessage != nil {
+		return msg.PtvMessage
+	}
+
 	if msg.StickerMessage != nil {
 		return msg.StickerMessage
 	}

--- a/src/whatsmeow/whatsmeow_handlers_message_extensions.go
+++ b/src/whatsmeow/whatsmeow_handlers_message_extensions.go
@@ -28,6 +28,9 @@ func HandleKnowingMessages(handler *WhatsmeowHandlers, out *whatsapp.WhatsappMes
 		HandleAudioMessage(logentry, out, in.AudioMessage)
 	case in.VideoMessage != nil:
 		HandleVideoMessage(logentry, out, in.VideoMessage)
+	case in.PtvMessage != nil:
+		HandleVideoMessage(logentry, out, in.PtvMessage)
+		out.InVideoNote = true
 	case in.ExtendedTextMessage != nil:
 		HandleExtendedTextMessage(logentry, out, in.ExtendedTextMessage)
 	case in.EphemeralMessage != nil:

--- a/src/whatsmeow/whatsmeow_handlers_message_extensions_test.go
+++ b/src/whatsmeow/whatsmeow_handlers_message_extensions_test.go
@@ -1,0 +1,69 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	whatsapp "github.com/nocodeleaks/quepasa/whatsapp"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHandleKnowingMessagesPtvMessageAsVideo(t *testing.T) {
+	handler := &WhatsmeowHandlers{}
+	out := &whatsapp.WhatsappMessage{
+		Id:   "test-message-id",
+		Chat: whatsapp.WhatsappChat{Id: "12345@s.whatsapp.net"},
+	}
+	in := &waE2E.Message{
+		PtvMessage: &waE2E.VideoMessage{
+			Caption:    proto.String("ptv caption"),
+			Mimetype:   proto.String("video/mp4"),
+			FileLength: proto.Uint64(123),
+		},
+	}
+
+	HandleKnowingMessages(handler, out, in)
+
+	if out.Type != whatsapp.VideoMessageType {
+		t.Fatalf("expected type %v, got %v", whatsapp.VideoMessageType, out.Type)
+	}
+
+	if out.Text != "ptv caption" {
+		t.Fatalf("expected caption %q, got %q", "ptv caption", out.Text)
+	}
+
+	if out.Attachment == nil {
+		t.Fatal("expected attachment to be set")
+	}
+
+	if out.Attachment.Mimetype != "video/mp4" {
+		t.Fatalf("expected mimetype %q, got %q", "video/mp4", out.Attachment.Mimetype)
+	}
+
+	if out.Attachment.FileLength != 123 {
+		t.Fatalf("expected file length %d, got %d", 123, out.Attachment.FileLength)
+	}
+
+	if !out.InVideoNote {
+		t.Fatal("expected invideonote=true for ptv message")
+	}
+}
+
+func TestGetDownloadableMessageReturnsPtvMessage(t *testing.T) {
+	ptv := &waE2E.VideoMessage{Mimetype: proto.String("video/mp4")}
+	msg := &waE2E.Message{PtvMessage: ptv}
+
+	got := GetDownloadableMessage(msg)
+	if got == nil {
+		t.Fatal("expected downloadable message, got nil")
+	}
+
+	video, ok := got.(*waE2E.VideoMessage)
+	if !ok {
+		t.Fatalf("expected *waE2E.VideoMessage, got %T", got)
+	}
+
+	if video != ptv {
+		t.Fatal("expected returned message to be the same ptv message pointer")
+	}
+}


### PR DESCRIPTION
This pull request adds support for handling WhatsApp video notes (PTV messages) as video messages in the codebase. The changes ensure that PTV messages are properly processed, marked, and tested for correct behavior. The most important changes are grouped below by theme.

### PTV Message Support

* Added a new `InVideoNote` field to the `WhatsappMessage` struct to indicate when a video message is a video note (PTV message).
* Updated the `HandleKnowingMessages` function to handle PTV messages as video messages and set the `InVideoNote` flag when appropriate.
* Modified the `GetDownloadableMessage` function to return the `PtvMessage` when present, ensuring video notes are downloadable like other video messages.

### Testing

* Added new unit tests in `whatsmeow_handlers_message_extensions_test.go` to verify that PTV messages are handled as video messages and that the `InVideoNote` flag is set correctly, as well as ensuring `GetDownloadableMessage` returns the correct message type for PTV messages.

### Version Update

* Updated the `QpVersion` constant in `qp_defaults.go` to reflect the new build version.