### PR TITLE
Feature/call offer lid pn mapping

### DIFF
--- a/src/models/qp_defaults.go
+++ b/src/models/qp_defaults.go
@@ -9,7 +9,7 @@ import (
 
 // quepasa build version format has 4 sections only: 3.YY.MMDD.HHMM
 // stable versions are identified when HHMM last digit is 0
-const QpVersion = "3.26.0402.1951"
+const QpVersion = "3.26.0406.1700"
 
 const QpLogLevel = log.InfoLevel
 

--- a/src/whatsmeow/whatsmeow_handlers.go
+++ b/src/whatsmeow/whatsmeow_handlers.go
@@ -833,7 +833,22 @@ func (source *WhatsmeowHandlers) CallMessage(evt types.BasicCallMeta) {
 	message.Timestamp = evt.Timestamp
 	message.FromMe = false
 
-	message.Chat = *NewWhatsappChat(source, evt.From)
+	// Resolve the best JID to use for the chat, preferring phone over LID when available
+	identifiers := ResolveCallIdentifiers(evt, logentry)
+
+	// If we have both LID and phone from the CallOffer, cache the mapping immediately
+	// so subsequent lookups don't have to query the database
+	if identifiers.HasLID && !identifiers.LidJID.IsEmpty() &&
+		identifiers.ChatJID.Server != whatsapp.WHATSAPP_SERVERDOMAIN_LID {
+		if cm, ok := source.GetContactManager().(*WhatsmeowContactManager); ok && cm != nil && cm.maps != nil {
+			lid := identifiers.LidJID.User + "@" + identifiers.LidJID.Server
+			cm.maps.SetPhoneFromLIDMap(lid, identifiers.ChatJID.User)
+			cm.maps.SetLIDFromPhoneMap(identifiers.ChatJID.User, lid)
+			logentry.Debugf("cached LID<->phone from CallOffer: %s <-> %s", lid, identifiers.ChatJID.User)
+		}
+	}
+
+	message.Chat = *NewWhatsappChat(source, identifiers.ChatJID)
 	message.Type = whatsapp.CallMessageType
 
 	if source.WAHandlers != nil {


### PR DESCRIPTION
This pull request includes an update to the build version and enhancements to how call message events resolve and cache WhatsApp chat identifiers. The most notable change is the improved logic for associating phone numbers with LID JIDs during call events, which helps optimize future lookups.

Enhancements to WhatsApp call message handling:

* Improved resolution of the best chat JID (phone or LID) for call messages by introducing the `ResolveCallIdentifiers` function, ensuring the correct identifier is used for each event.
* Added immediate caching of the LID-to-phone and phone-to-LID mappings when both are available from a call offer, reducing the need for future database queries and improving performance.

Version update:

* Updated the `QpVersion` constant in `qp_defaults.go` to `3.26.0406.1700`.