### PR TITLE
Feature/save contact on phone

### DIFF
--- a/src/api/api_handlers+ContactSaveController.go
+++ b/src/api/api_handlers+ContactSaveController.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	models "github.com/nocodeleaks/quepasa/models"
+	whatsapp "github.com/nocodeleaks/quepasa/whatsapp"
+	whatsmeow "github.com/nocodeleaks/quepasa/whatsmeow"
+)
+
+// ContactSaveRequest defines the parameters for saving a contact
+type ContactSaveRequest struct {
+	Phone       string `json:"phone"`                  // Required: phone number (e.g. 5516998824990)
+	FullName    string `json:"fullname"`               // Required: full name
+	FirstName   string `json:"firstname,omitempty"`    // Optional: first name (defaults to FullName if empty)
+	SyncToPhone bool   `json:"synctophone,omitempty"` // Optional: sync to phone address book (default false)
+}
+
+// ContactSaveController handles API requests for saving a contact
+//
+//	@Summary		Save contact
+//	@Description	Saves a contact to WhatsApp address book. Set synctophone=true to also sync to the device's contacts (equivalent to "Sync contact with phone" in WhatsApp Web)
+//	@Tags			Contacts
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		ContactSaveRequest	true	"Contact save request"
+//	@Success		200		{object}	models.QpResponse
+//	@Failure		400		{object}	models.QpResponse
+//	@Failure		503		{object}	models.QpResponse
+//	@Security		ApiKeyAuth
+//	@Router			/contact/save [post]
+func ContactSaveController(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	response := &models.QpResponse{}
+
+	server, err := GetServer(r)
+	if err != nil {
+		response.ParseError(err)
+		RespondInterface(w, response)
+		return
+	}
+
+	logentry := server.GetLogger()
+
+	var request ContactSaveRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		response.ParseError(fmt.Errorf("invalid request: %v", err))
+		RespondInterface(w, response)
+		return
+	}
+
+	// Validate required fields
+	request.Phone = strings.TrimSpace(request.Phone)
+	request.FullName = strings.TrimSpace(request.FullName)
+	if request.Phone == "" {
+		response.ParseError(fmt.Errorf("phone is required"))
+		RespondInterface(w, response)
+		return
+	}
+	if request.FullName == "" {
+		response.ParseError(fmt.Errorf("fullname is required"))
+		RespondInterface(w, response)
+		return
+	}
+
+	// Normalize phone: strip leading + and any non-digit chars except leading +
+	phone := strings.TrimPrefix(request.Phone, "+")
+
+	// Default firstname to fullname if not provided
+	firstName := strings.TrimSpace(request.FirstName)
+	if firstName == "" {
+		firstName = request.FullName
+	}
+
+	// Checking for ready state
+	status := server.GetStatus()
+	if status != whatsapp.Ready {
+		err = &ApiServerNotReadyException{Wid: server.GetWId(), Status: status}
+		response.ParseError(err)
+		RespondInterfaceCode(w, response, http.StatusServiceUnavailable)
+		return
+	}
+
+	conn := server.GetConnection().(*whatsmeow.WhatsmeowConnection)
+
+	if err := whatsmeow.SaveContact(conn, phone, request.FullName, firstName, request.SyncToPhone); err != nil {
+		response.ParseError(fmt.Errorf("failed to save contact: %v", err))
+		RespondInterface(w, response)
+		return
+	}
+
+	logentry.Infof("saved contact: %s (%s), synctophone=%v", request.FullName, phone, request.SyncToPhone)
+
+	response.Success = true
+	response.ParseSuccess(fmt.Sprintf("contact %s (%s) saved", request.FullName, phone))
+	RespondInterface(w, response)
+}

--- a/src/api/api_handlers+ContactSaveController.go
+++ b/src/api/api_handlers+ContactSaveController.go
@@ -13,9 +13,9 @@ import (
 
 // ContactSaveRequest defines the parameters for saving a contact
 type ContactSaveRequest struct {
-	Phone       string `json:"phone"`                  // Required: phone number (e.g. 5516998824990)
-	FullName    string `json:"fullname"`               // Required: full name
-	FirstName   string `json:"firstname,omitempty"`    // Optional: first name (defaults to FullName if empty)
+	Phone       string `json:"phone"`                 // Required: phone number (e.g. 5516998824990)
+	FullName    string `json:"fullname"`              // Required: full name
+	FirstName   string `json:"firstname,omitempty"`   // Optional: first name (defaults to FullName if empty)
 	SyncToPhone bool   `json:"synctophone,omitempty"` // Optional: sync to phone address book (default false)
 }
 

--- a/src/api/api_handlers.go
+++ b/src/api/api_handlers.go
@@ -127,6 +127,7 @@ func RegisterAPIControllers(r chi.Router) {
 		// INVITE METHODS ************************
 
 		r.Get(endpoint+"/contacts", ContactsController)
+		r.Post(endpoint+"/contact/save", ContactSaveController)
 		r.Post(endpoint+"/contact/search", ContactSearchController)
 		r.Post(endpoint+"/isonwhatsapp", IsOnWhatsappController)
 

--- a/src/models/qp_defaults.go
+++ b/src/models/qp_defaults.go
@@ -9,7 +9,7 @@ import (
 
 // quepasa build version format has 4 sections only: 3.YY.MMDD.HHMM
 // stable versions are identified when HHMM last digit is 0
-const QpVersion = "3.26.0402.1951"
+const QpVersion = "3.26.0406.1735"
 
 const QpLogLevel = log.InfoLevel
 

--- a/src/swagger/docs.go
+++ b/src/swagger/docs.go
@@ -328,6 +328,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/contact/save": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Saves a contact to WhatsApp address book. Set synctophone=true to also sync to the device's contacts (equivalent to \"Sync contact with phone\" in WhatsApp Web)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Save contact",
+                "parameters": [
+                    {
+                        "description": "Contact save request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.ContactSaveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/contact/search": {
             "post": {
                 "security": [
@@ -2497,6 +2548,27 @@ const docTemplate = `{
                 "chatid": {
                     "description": "Required: Chat to mark as read/unread",
                     "type": "string"
+                }
+            }
+        },
+        "api.ContactSaveRequest": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "description": "Optional: first name (defaults to FullName if empty)",
+                    "type": "string"
+                },
+                "fullname": {
+                    "description": "Required: full name",
+                    "type": "string"
+                },
+                "phone": {
+                    "description": "Required: phone number (e.g. 5516998824990)",
+                    "type": "string"
+                },
+                "synctophone": {
+                    "description": "Optional: sync to phone address book (default false)",
+                    "type": "boolean"
                 }
             }
         },

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -325,6 +325,57 @@
                 }
             }
         },
+        "/contact/save": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Saves a contact to WhatsApp address book. Set synctophone=true to also sync to the device's contacts (equivalent to \"Sync contact with phone\" in WhatsApp Web)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Save contact",
+                "parameters": [
+                    {
+                        "description": "Contact save request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.ContactSaveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.QpResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/contact/search": {
             "post": {
                 "security": [
@@ -2494,6 +2545,27 @@
                 "chatid": {
                     "description": "Required: Chat to mark as read/unread",
                     "type": "string"
+                }
+            }
+        },
+        "api.ContactSaveRequest": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "description": "Optional: first name (defaults to FullName if empty)",
+                    "type": "string"
+                },
+                "fullname": {
+                    "description": "Required: full name",
+                    "type": "string"
+                },
+                "phone": {
+                    "description": "Required: phone number (e.g. 5516998824990)",
+                    "type": "string"
+                },
+                "synctophone": {
+                    "description": "Optional: sync to phone address book (default false)",
+                    "type": "boolean"
                 }
             }
         },

--- a/src/swagger/swagger.yaml
+++ b/src/swagger/swagger.yaml
@@ -28,6 +28,21 @@ definitions:
         description: 'Required: Chat to mark as read/unread'
         type: string
     type: object
+  api.ContactSaveRequest:
+    properties:
+      firstname:
+        description: 'Optional: first name (defaults to FullName if empty)'
+        type: string
+      fullname:
+        description: 'Required: full name'
+        type: string
+      phone:
+        description: 'Required: phone number (e.g. 5516998824990)'
+        type: string
+      synctophone:
+        description: 'Optional: sync to phone address book (default false)'
+        type: boolean
+    type: object
   api.EnvironmentResponse:
     properties:
       debug:
@@ -1509,6 +1524,40 @@ paths:
       summary: Execute bot commands
       tags:
       - Bot
+  /contact/save:
+    post:
+      consumes:
+      - application/json
+      description: Saves a contact to WhatsApp address book. Set synctophone=true
+        to also sync to the device's contacts (equivalent to "Sync contact with phone"
+        in WhatsApp Web)
+      parameters:
+      - description: Contact save request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/api.ContactSaveRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.QpResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.QpResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/models.QpResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Save contact
+      tags:
+      - Contacts
   /contact/search:
     post:
       consumes:

--- a/src/whatsmeow/whatsmeow_appstate.go
+++ b/src/whatsmeow/whatsmeow_appstate.go
@@ -1,0 +1,95 @@
+package whatsmeow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	whatsapp "github.com/nocodeleaks/quepasa/whatsapp"
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waSyncAction"
+	types "go.mau.fi/whatsmeow/types"
+)
+
+// sendAppState sends app state patch to WhatsApp (no retry, returns error as-is)
+func sendAppState(conn *WhatsmeowConnection, patch appstate.PatchInfo) error {
+	ctx := context.Background()
+	return conn.Client.SendAppState(ctx, patch)
+}
+
+// MarkChatAsRead marks a chat as read using app state protocol
+func MarkChatAsRead(conn *WhatsmeowConnection, chatId string) error {
+	if conn.Client == nil {
+		return fmt.Errorf("client not defined")
+	}
+
+	jid, err := types.ParseJID(chatId)
+	if err != nil {
+		return fmt.Errorf("invalid chat id format: %v", err)
+	}
+
+	patch := appstate.BuildMarkChatAsRead(jid, true, time.Time{}, nil)
+	return sendAppState(conn, patch)
+}
+
+// MarkChatAsUnread marks a chat as unread using app state protocol
+func MarkChatAsUnread(conn *WhatsmeowConnection, chatId string) error {
+	if conn.Client == nil {
+		return fmt.Errorf("client not defined")
+	}
+
+	jid, err := types.ParseJID(chatId)
+	if err != nil {
+		return fmt.Errorf("invalid chat id format: %v", err)
+	}
+
+	patch := appstate.BuildMarkChatAsRead(jid, false, time.Time{}, nil)
+	return sendAppState(conn, patch)
+}
+
+// ArchiveChat archives or unarchives a chat using app state protocol
+func ArchiveChat(conn *WhatsmeowConnection, chatId string, archive bool) error {
+	if conn.Client == nil {
+		return fmt.Errorf("client not defined")
+	}
+
+	jid, err := types.ParseJID(chatId)
+	if err != nil {
+		return fmt.Errorf("invalid chat id format: %v", err)
+	}
+
+	patch := appstate.BuildArchive(jid, archive, time.Time{}, nil)
+	return sendAppState(conn, patch)
+}
+
+// SaveContact saves a contact to the WhatsApp address book and syncs it to the phone
+// when syncToPhone is true, equivalent to "Sync contact with phone" in WhatsApp Web
+func SaveContact(conn *WhatsmeowConnection, phone, fullName, firstName string, syncToPhone bool) error {
+	if conn.Client == nil {
+		return fmt.Errorf("client not defined")
+	}
+
+	phoneJID := types.JID{
+		User:   phone,
+		Server: whatsapp.WHATSAPP_SERVERDOMAIN_USER,
+	}
+
+	patch := appstate.PatchInfo{
+		Type: appstate.WAPatchRegularHigh,
+		Mutations: []appstate.MutationInfo{{
+			Index:   []string{appstate.IndexContact, phoneJID.String()},
+			Version: 2,
+			Value: &waSyncAction.SyncActionValue{
+				ContactAction: &waSyncAction.ContactAction{
+					FullName:                 proto.String(fullName),
+					FirstName:                proto.String(firstName),
+					SaveOnPrimaryAddressbook: proto.Bool(syncToPhone),
+				},
+			},
+		}},
+	}
+
+	return sendAppState(conn, patch)
+}

--- a/src/whatsmeow/whatsmeow_connection.go
+++ b/src/whatsmeow/whatsmeow_connection.go
@@ -16,7 +16,6 @@ import (
 	library "github.com/nocodeleaks/quepasa/library"
 	whatsapp "github.com/nocodeleaks/quepasa/whatsapp"
 	whatsmeow "go.mau.fi/whatsmeow"
-	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	types "go.mau.fi/whatsmeow/types"
 )
@@ -1174,57 +1173,6 @@ func (conn *WhatsmeowConnection) SendChatPresence(chatId string, presenceType ui
 		media = types.ChatPresenceMediaText
 	}
 	return conn.Client.SendChatPresence(context.Background(), jid, state, media)
-}
-
-// sendAppState sends app state patch to WhatsApp (no retry, returns error as-is)
-func sendAppState(conn *WhatsmeowConnection, patch appstate.PatchInfo) error {
-	ctx := context.Background()
-	return conn.Client.SendAppState(ctx, patch)
-}
-
-// MarkChatAsRead marks a chat as read using app state protocol
-func MarkChatAsRead(conn *WhatsmeowConnection, chatId string) error {
-	if conn.Client == nil {
-		return fmt.Errorf("client not defined")
-	}
-
-	jid, err := types.ParseJID(chatId)
-	if err != nil {
-		return fmt.Errorf("invalid chat id format: %v", err)
-	}
-
-	patch := appstate.BuildMarkChatAsRead(jid, true, time.Time{}, nil)
-	return sendAppState(conn, patch)
-}
-
-// MarkChatAsUnread marks a chat as unread using app state protocol
-func MarkChatAsUnread(conn *WhatsmeowConnection, chatId string) error {
-	if conn.Client == nil {
-		return fmt.Errorf("client not defined")
-	}
-
-	jid, err := types.ParseJID(chatId)
-	if err != nil {
-		return fmt.Errorf("invalid chat id format: %v", err)
-	}
-
-	patch := appstate.BuildMarkChatAsRead(jid, false, time.Time{}, nil)
-	return sendAppState(conn, patch)
-}
-
-// ArchiveChat archives or unarchives a chat using app state protocol
-func ArchiveChat(conn *WhatsmeowConnection, chatId string, archive bool) error {
-	if conn.Client == nil {
-		return fmt.Errorf("client not defined")
-	}
-
-	jid, err := types.ParseJID(chatId)
-	if err != nil {
-		return fmt.Errorf("invalid chat id format: %v", err)
-	}
-
-	patch := appstate.BuildArchive(jid, archive, time.Time{}, nil)
-	return sendAppState(conn, patch)
 }
 
 //#region HANDLER MANAGEMENT


### PR DESCRIPTION
This pull request adds a new API endpoint for saving contacts to the WhatsApp address book, with an option to sync contacts to the device's phonebook. It introduces the necessary controller, request model, and updates the OpenAPI/Swagger documentation accordingly. Additionally, it refactors some existing WhatsApp app state logic into a new dedicated file to improve code organization.

**New API functionality:**

* Adds a new POST `/contact/save` endpoint to save a contact to the WhatsApp address book, with support for syncing to the device's contacts. This includes input validation and proper error handling in the new `ContactSaveController`. [[1]](diffhunk://#diff-c6e5ee252b5bf6d19ef957fdbb556e4bea824a454f78e54434909606829b3ddaR1-R101) [[2]](diffhunk://#diff-6ae63fe88848d954903f2d9d91c969a4e284292b7d0ddb3a3dc2ef634f64929eR130)

**OpenAPI/Swagger documentation updates:**

* Documents the new `/contact/save` endpoint, including request/response schemas and descriptions, in `swagger.yaml`, `swagger.json`, and `docs.go`. Also defines the `api.ContactSaveRequest` schema for use in the API docs. [[1]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R331-R381) [[2]](diffhunk://#diff-f8909325758052bf0b3d4cc60fd66787154c81001a178774f7b0ebc6bfb14778R2554-R2574) [[3]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR328-R378) [[4]](diffhunk://#diff-89c22a9f88cdaecd60b313f8d8ef3c42d860a8c181638a9dd15b9a23d9f2a87fR2551-R2571) [[5]](diffhunk://#diff-63ea78f739530e7b938895275735c4444a674ff143393c1455cdf77373db44e7R31-R45) [[6]](diffhunk://#diff-63ea78f739530e7b938895275735c4444a674ff143393c1455cdf77373db44e7R1527-R1560)

**Code organization and refactoring:**

* Moves WhatsApp app state helper functions (`MarkChatAsRead`, `MarkChatAsUnread`, `ArchiveChat`, and the new `SaveContact`) from `whatsmeow_connection.go` to a new file `whatsmeow_appstate.go` for better separation of concerns. Removes the old implementations from `whatsmeow_connection.go`. [[1]](diffhunk://#diff-b6986df37ba64752af3c69522cb147eaf87c8d3b06e26e2ae12a9c16f744bca0R1-R95) [[2]](diffhunk://#diff-6b86f38b6fc34f5014a284ec1a3ea3d480b28ab1e40f52f3260a76ba069ec8c9L19) [[3]](diffhunk://#diff-6b86f38b6fc34f5014a284ec1a3ea3d480b28ab1e40f52f3260a76ba069ec8c9L1179-L1229)